### PR TITLE
fixes #6 (problem with non-English default locale)

### DIFF
--- a/src/main/java/com/mailgun/model/domains/Domain.java
+++ b/src/main/java/com/mailgun/model/domains/Domain.java
@@ -158,7 +158,7 @@ public class Domain {
      * </p>
      * {@link ZonedDateTime}
      */
-    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME)
+    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME, locale = "en")
     @JsonProperty("created_at")
     ZonedDateTime createdAt;
 

--- a/src/main/java/com/mailgun/model/mailing/lists/MailingListData.java
+++ b/src/main/java/com/mailgun/model/mailing/lists/MailingListData.java
@@ -48,7 +48,7 @@ public class MailingListData {
      * </p>
      * {@link ZonedDateTime}
      */
-    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NUMERIC)
+    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NUMERIC, locale = "en")
     @JsonProperty("created_at")
     ZonedDateTime createdAt;
 

--- a/src/main/java/com/mailgun/model/mailing/lists/MailingListVerificationStatusResponse.java
+++ b/src/main/java/com/mailgun/model/mailing/lists/MailingListVerificationStatusResponse.java
@@ -57,7 +57,7 @@ public class MailingListVerificationStatusResponse {
      * </p>
      * {@link ZonedDateTime}
      */
-    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME)
+    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME, locale = "en")
     @JsonProperty("created_at")
     ZonedDateTime createdAt;
 

--- a/src/main/java/com/mailgun/model/routes/Route.java
+++ b/src/main/java/com/mailgun/model/routes/Route.java
@@ -67,7 +67,7 @@ public class Route {
      * </p>
      * {@link ZonedDateTime}
      */
-    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME)
+    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME, locale = "en")
     @JsonProperty("created_at")
     ZonedDateTime createdAt;
 

--- a/src/main/java/com/mailgun/model/stats/Stats.java
+++ b/src/main/java/com/mailgun/model/stats/Stats.java
@@ -28,7 +28,7 @@ public class Stats {
      * The starting time.
      * </p>
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME, locale = "en")
     ZonedDateTime time;
 
     /**

--- a/src/main/java/com/mailgun/model/stats/StatsResult.java
+++ b/src/main/java/com/mailgun/model/stats/StatsResult.java
@@ -37,7 +37,7 @@ public class StatsResult {
      * The starting time.
      * </p>
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME, locale = "en")
     ZonedDateTime start;
 
     /**
@@ -45,7 +45,7 @@ public class StatsResult {
      * The ending date.
      * </p>
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME, locale = "en")
     ZonedDateTime end;
 
     /**

--- a/src/main/java/com/mailgun/model/suppression/bounces/BouncesItem.java
+++ b/src/main/java/com/mailgun/model/suppression/bounces/BouncesItem.java
@@ -50,7 +50,7 @@ public class BouncesItem {
      * Timestamp of a bounce event.
      * </p>
      */
-    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME)
+    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME, locale = "en")
     @JsonProperty("created_at")
     ZonedDateTime createdAt;
 

--- a/src/main/java/com/mailgun/model/suppression/complaints/ComplaintsItem.java
+++ b/src/main/java/com/mailgun/model/suppression/complaints/ComplaintsItem.java
@@ -39,7 +39,7 @@ public class ComplaintsItem {
      * </p>
      * {@link ZonedDateTime}
      */
-    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME_DAY_OCTAL_LITERAL)
+    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME_DAY_OCTAL_LITERAL, locale = "en")
     @JsonProperty("created_at")
     ZonedDateTime createdAt;
 

--- a/src/main/java/com/mailgun/model/suppression/unsubscribe/UnsubscribeItem.java
+++ b/src/main/java/com/mailgun/model/suppression/unsubscribe/UnsubscribeItem.java
@@ -51,7 +51,7 @@ public class UnsubscribeItem {
      * </p>
      * {@link ZonedDateTime}
      */
-    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME_DAY_OCTAL_LITERAL)
+    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME_DAY_OCTAL_LITERAL, locale = "en")
     @JsonProperty("created_at")
     ZonedDateTime createdAt;
 

--- a/src/main/java/com/mailgun/model/suppression/whitelists/WhitelistsItem.java
+++ b/src/main/java/com/mailgun/model/suppression/whitelists/WhitelistsItem.java
@@ -54,7 +54,7 @@ public class WhitelistsItem {
      * </p>
      * {@link ZonedDateTime}
      */
-    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME)
+    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME, locale = "en")
     ZonedDateTime createdAt;
 
 }

--- a/src/main/java/com/mailgun/model/tags/TagStatsResult.java
+++ b/src/main/java/com/mailgun/model/tags/TagStatsResult.java
@@ -45,7 +45,7 @@ public class TagStatsResult {
      * The starting time.
      * </p>
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME, locale = "en")
     ZonedDateTime start;
 
     /**
@@ -53,7 +53,7 @@ public class TagStatsResult {
      * The ending date.
      * </p>
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME, locale = "en")
     ZonedDateTime end;
 
     /**

--- a/src/main/java/com/mailgun/model/templates/Template.java
+++ b/src/main/java/com/mailgun/model/templates/Template.java
@@ -50,7 +50,7 @@ public class Template {
      * </p>
      * {@link ZonedDateTime}
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME, locale = "en")
     ZonedDateTime createdAt;
 
     String createdBy;

--- a/src/main/java/com/mailgun/model/templates/TemplateVersion.java
+++ b/src/main/java/com/mailgun/model/templates/TemplateVersion.java
@@ -69,7 +69,7 @@ public class TemplateVersion {
      * </p>
      * {@link ZonedDateTime}
      */
-    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME)
+    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME, locale = "en")
     ZonedDateTime createdAt;
 
     /**

--- a/src/main/java/com/mailgun/model/templates/TemplateVersions.java
+++ b/src/main/java/com/mailgun/model/templates/TemplateVersions.java
@@ -61,7 +61,7 @@ public class TemplateVersions {
      * </p>
      * {@link ZonedDateTime}
      */
-    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME)
+    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME, locale = "en")
     ZonedDateTime createdAt;
 
     /**

--- a/src/main/java/com/mailgun/model/templates/TemplateWithVersion.java
+++ b/src/main/java/com/mailgun/model/templates/TemplateWithVersion.java
@@ -50,7 +50,7 @@ public class TemplateWithVersion {
      * </p>
      * {@link ZonedDateTime}
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME, locale = "en")
     ZonedDateTime createdAt;
 
     String createdBy;

--- a/src/main/java/com/mailgun/model/templates/TemplateWithVersions.java
+++ b/src/main/java/com/mailgun/model/templates/TemplateWithVersions.java
@@ -51,7 +51,7 @@ public class TemplateWithVersions {
      * </p>
      * {@link ZonedDateTime}
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME, locale = "en")
     ZonedDateTime createdAt;
 
     String createdBy;

--- a/src/main/java/com/mailgun/model/verification/BulkVerificationJobStatusResponse.java
+++ b/src/main/java/com/mailgun/model/verification/BulkVerificationJobStatusResponse.java
@@ -68,7 +68,7 @@ public class BulkVerificationJobStatusResponse {
      * </p>
      * {@link ZonedDateTime}
      */
-    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME)
+    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME, locale = "en")
     @JsonProperty("created_at")
     ZonedDateTime createdAt;
 

--- a/src/main/java/com/mailgun/model/verification/BulkVerificationPreviewStatusResponse.java
+++ b/src/main/java/com/mailgun/model/verification/BulkVerificationPreviewStatusResponse.java
@@ -70,7 +70,7 @@ public class BulkVerificationPreviewStatusResponse {
      * </p>
      * {@link ZonedDateTime}
      */
-    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME)
+    @JsonFormat(pattern = RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME, locale = "en")
     @JsonProperty("created_at")
     ZonedDateTime createdAt;
 

--- a/src/main/java/com/mailgun/util/DateTimeUtil.java
+++ b/src/main/java/com/mailgun/util/DateTimeUtil.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 import static com.mailgun.util.Constants.RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME_DAY_OCTAL_LITERAL;
 import static com.mailgun.util.Constants.RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NUMERIC;
@@ -15,8 +16,8 @@ public class DateTimeUtil {
 
     private static final String UNABLE_TO_FORMAT_PROVIDED_ZONED_DATE_TIME = "Unable to format provided ZonedDateTime";
 
-    private static final DateTimeFormatter FORMATTER_DATE_TIME_PATTERN_TIME_ZONE = DateTimeFormatter.ofPattern(RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NUMERIC);
-    private static final DateTimeFormatter FORMATTER_DATE_TIME_TIME_ZONE_NAME_DAY = DateTimeFormatter.ofPattern(RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME_DAY_OCTAL_LITERAL);
+    private static final DateTimeFormatter FORMATTER_DATE_TIME_PATTERN_TIME_ZONE = DateTimeFormatter.ofPattern(RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NUMERIC, Locale.ENGLISH);
+    private static final DateTimeFormatter FORMATTER_DATE_TIME_TIME_ZONE_NAME_DAY = DateTimeFormatter.ofPattern(RFC_2822_DATE_TIME_PATTERN_TIME_ZONE_NAME_DAY_OCTAL_LITERAL, Locale.ENGLISH);
 
     public static String toString(ZonedDateTime zonedDateTime) {
         try {

--- a/src/test/java/com/mailgun/model/stats/StatisticsOptionsTest.java
+++ b/src/test/java/com/mailgun/model/stats/StatisticsOptionsTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.Locale;
 
 import static com.mailgun.constants.TestConstants.ZONED_DATE_TIME_2018_2_3_GMT;
 import static com.mailgun.constants.TestConstants.ZONED_DATE_TIME_2018_2_3_STRING;


### PR DESCRIPTION
This commits changes the library to explicitly set the locale to "en" to prevent parsing error when standard locale is not "en"