### PR TITLE
add custom headers support for emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All _notable_ changes to this project will be documented in this file.
 The format is based on _[Keep a Changelog][keepachangelog]_, and this project
 adheres to _[Semantic Versioning][semver]_.
 
+## [1.1.2] (released: 2024-01-26)
+### Updated
+- add ability for MailgunMessagesApi to support arbitrary email headers through `.headers`.
+
 ## [1.1.1] (released: 2023-12-12)
 ### Updated
 - add ability for primary accounts to make API calls on behalf of their subaccounts, e.g. sending messages, managing mailing lists, etc.
@@ -67,6 +71,7 @@ adheres to _[Semantic Versioning][semver]_.
 - Add Import a list of bounces from CSV file API
 
 
+[1.1.2]: https://github.com/mailgun/mailgun-java/compare/release/1.1.1...release/1.1.2
 [1.1.1]: https://github.com/mailgun/mailgun-java/compare/release/1.1.0...release/1.1.1
 [1.1.0]: https://github.com/mailgun/mailgun-java/compare/release/1.0.9...release/1.1.0
 [1.0.9]: https://github.com/mailgun/mailgun-java/compare/release/1.0.8...release/1.0.9

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Add the following to your `pom.xml`:
   <dependency>
     <groupId>com.mailgun</groupId>
     <artifactId>mailgun-java</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
   </dependency>
   ...
 </dependencies>
@@ -85,7 +85,7 @@ Add the following to your `pom.xml`:
 Gradle Groovy DSL .
 
 ```xml
-implementation 'com.mailgun:mailgun-java:1.1.1'
+implementation 'com.mailgun:mailgun-java:1.1.2'
 ```
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.mailgun</groupId>
     <artifactId>mailgun-java</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/mailgun/form/CustomProperties.java
+++ b/src/main/java/com/mailgun/form/CustomProperties.java
@@ -1,0 +1,20 @@
+package com.mailgun.form;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Target(FIELD)
+@Retention(RUNTIME)
+public @interface CustomProperties {
+
+    /**
+     * The name of the property.
+     */
+    String prefix ();
+
+}

--- a/src/main/java/com/mailgun/form/FormEncoder.java
+++ b/src/main/java/com/mailgun/form/FormEncoder.java
@@ -16,8 +16,8 @@ import feign.form.UrlencodedFormContentProcessor;
 import feign.form.util.CharsetUtil;
 import lombok.val;
 
-import static feign.form.util.PojoUtil.isUserPojo;
-import static feign.form.util.PojoUtil.toMap;
+import static com.mailgun.form.PojoUtil.isUserPojo;
+import static com.mailgun.form.PojoUtil.toMap;
 import static java.util.Arrays.asList;
 
 public class FormEncoder implements Encoder {

--- a/src/main/java/com/mailgun/form/PojoUtil.java
+++ b/src/main/java/com/mailgun/form/PojoUtil.java
@@ -1,0 +1,88 @@
+package com.mailgun.form;
+
+import feign.form.FormProperty;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.rmi.UnexpectedException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.lang.reflect.Modifier.isFinal;
+import static java.lang.reflect.Modifier.isStatic;
+import static lombok.AccessLevel.PRIVATE;
+
+/**
+ *
+ * @author Artem Labazin
+ */
+public final class PojoUtil {
+
+    public static boolean isUserPojo (@NonNull Object object) {
+        val type = object.getClass();
+        val packageName = type.getPackage().getName();
+        return !packageName.startsWith("java.");
+    }
+
+    public static boolean isUserPojo (@NonNull Type type) {
+        val typeName = type.toString();
+        return !typeName.startsWith("class java.");
+    }
+
+    @SneakyThrows
+    public static Map<String, Object> toMap (@NonNull Object object) {
+        val result = new HashMap<String, Object>();
+        val type = object.getClass();
+        val setAccessibleAction = new PojoUtil.SetAccessibleAction();
+        for (val field : type.getDeclaredFields()) {
+            val modifiers = field.getModifiers();
+            if (isFinal(modifiers) || isStatic(modifiers)) {
+                continue;
+            }
+            setAccessibleAction.setField(field);
+            AccessController.doPrivileged(setAccessibleAction);
+
+            val fieldValue = field.get(object);
+            if (fieldValue == null) {
+                continue;
+            }
+            if (field.isAnnotationPresent(CustomProperties.class)) {
+                String prefix = field.getAnnotation(CustomProperties.class).prefix();
+                Map<String, String> properties = (Map<String, String>) fieldValue;
+                for (Map.Entry<String, String> entry : properties.entrySet()) {
+                    result.put(prefix + entry.getKey(), entry.getValue());
+                }
+            } else {
+                val propertyKey = field.isAnnotationPresent(FormProperty.class)
+                        ? field.getAnnotation(FormProperty.class).value()
+                        : field.getName();
+
+                result.put(propertyKey, fieldValue);
+            }
+
+        }
+        return result;
+    }
+
+    private PojoUtil () throws UnexpectedException {
+        throw new UnexpectedException("It is not allowed to instantiate this class");
+    }
+
+    @Setter
+    @NoArgsConstructor
+    @FieldDefaults(level = PRIVATE)
+    private static class SetAccessibleAction implements PrivilegedAction<Object> {
+
+        Field field;
+
+        @Override
+        public Object run () {
+            field.setAccessible(true);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/mailgun/form/PojoUtil.java
+++ b/src/main/java/com/mailgun/form/PojoUtil.java
@@ -1,8 +1,12 @@
 package com.mailgun.form;
 
 import feign.form.FormProperty;
-import lombok.*;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.SneakyThrows;
 import lombok.experimental.FieldDefaults;
+import lombok.val;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;

--- a/src/main/java/com/mailgun/model/message/Message.java
+++ b/src/main/java/com/mailgun/model/message/Message.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.mailgun.form.CustomProperties;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -286,6 +287,14 @@ public class Message {
      */
     @FormProperty("t:variables")
     String mailgunVariables;
+
+    /**
+     * <p>
+     * Specify custom email headers
+     * </p>
+     */
+    @CustomProperties(prefix = "h:")
+    Map<String, String> headers;
 
     public static MessageBuilder builder() {
         return new CustomMessageBuilder();
@@ -766,6 +775,19 @@ public class Message {
          */
         public MessageBuilder mailgunVariables(String mailgunVariables) {
             this.mailgunVariables = mailgunVariables;
+            return this;
+        }
+
+        /**
+         * <p>
+         * Specify custom email headers
+         * </p>
+         *
+         * @param headers custom email headers
+         * @return Returns a reference to this object so that method calls can be chained together.
+         */
+        public MessageBuilder headers(Map<String, String> headers) {
+            this.headers = headers;
             return this;
         }
     }


### PR DESCRIPTION
Looks like the request interceptor doesn't work quite well with dynamic values unless we create a new client for every message. This is to add a custom email headers support with a custom Java annotations. 